### PR TITLE
Feature/store genre options

### DIFF
--- a/src/containers/genres/genres.html
+++ b/src/containers/genres/genres.html
@@ -100,5 +100,6 @@
 </main>
 <script src="https://code.jquery.com/jquery-3.6.0.js" integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk=" crossorigin="anonymous"></script>
 <script src="../navigation-bar/js/nav.js"></script>
+<script src="js/genres.js"></script>
 </body>
 </html>

--- a/src/containers/genres/genres.html
+++ b/src/containers/genres/genres.html
@@ -18,7 +18,9 @@
   <nav></nav>
 
   <main>
-    
+
+    <form>
+
     <div id = "genres" class = "columns">
 
       <div id="genreYes" class = "column">
@@ -26,32 +28,32 @@
         <div class = "box">
           <table class = "table">
             <tr>
-              <th><label class="checkbox"><input type="checkbox"> Comedy <i class="fas fa-laugh-squint"></i></label></th>
-              <th><label class="checkbox"><input type="checkbox"> Crime <i class="fas fa-user-ninja"></i></label></th>
-              <th><label class="checkbox"><input type="checkbox"> Thriller <i class="fas fa-crow"></i></label></th>
-              <th><label class="checkbox"><input type="checkbox"> Adventure <i class="fas fa-map-signs"></i></label></th>
-              <th><label class="checkbox"><input type="checkbox"> Sport <i class="fas fa-football-ball"></i></label></th>
+              <th><label class="checkbox"><input type="checkbox" data-index="Comedy" class="yes"> Comedy <i class="fas fa-laugh-squint"></i></label></th>
+              <th><label class="checkbox"><input type="checkbox" data-index="Crime" class="yes"> Crime <i class="fas fa-user-ninja"></i></label></th>
+              <th><label class="checkbox"><input type="checkbox" data-index="Thriller" class="yes"> Thriller <i class="fas fa-crow"></i></label></th>
+              <th><label class="checkbox"><input type="checkbox" data-index="Adventure" class="yes"> Adventure <i class="fas fa-map-signs"></i></label></th>
+              <th><label class="checkbox"><input type="checkbox" data-index="Western" class="yes"> Western <i class="fab fa-sticker-mule"></i></label></th>
             </tr>       
             <tr>
-                <th><label class="checkbox"><input type="checkbox"> Family <i class="fas fa-home"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> Fantasy <i class="fas fa-dragon"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> Action <i class="fas fa-bomb"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> Detective <i class="fas fa-user-secret"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> Horror <i class="fas fa-ghost"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Family" class="yes"> Family <i class="fas fa-home"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Fantasy" class="yes"> Fantasy <i class="fas fa-dragon"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Action" class="yes"> Action <i class="fas fa-bomb"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Documentary" class="yes"> Doc <i class="fas fa-video"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Horror" class="yes"> Horror <i class="fas fa-ghost"></i></label></th>
               </tr>         
               <tr>
-                <th><label class="checkbox"><input type="checkbox"> Romance <i class="fas fa-heart"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> Biography <i class="fas fa-user-tie"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> History <i class="fab fa-fort-awesome"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> Mystery <i class="fas fa-search"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> Musical <i class="fas fa-music"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Romance" class="yes"> Romance <i class="fas fa-heart"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="TV Movie" class="yes"> TV Movie <i class="fas fa-tv"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="History" class="yes"> History <i class="fab fa-fort-awesome"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Mystery" class="yes"> Mystery <i class="fas fa-user-secret"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Music" class="yes"> Musical <i class="fas fa-music"></i></label></th>
               </tr>         
               <tr>
-                <th><label class="checkbox"><input type="checkbox"> Drama <i class="fas fa-theater-masks"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> Sci-Fi <i class="fas fa-robot"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> War <i class="fas fa-fighter-jet"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> Animation <i class="fab fa-optin-monster"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox"> Western <i class="fab fa-sticker-mule"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Drama" class="yes"> Drama <i class="fas fa-theater-masks"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Science Fiction" class="yes"> Sci-Fi <i class="fas fa-robot"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="War" class="yes"> War <i class="fas fa-fighter-jet"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Animation" class="yes"> Animation <i class="fab fa-optin-monster"></i></label></th>
+
               </tr>         
           </table>
         </div>
@@ -61,45 +63,47 @@
           <h2 class="title is-2">No way</h2>
           <div class = "box">
             <table class = "table">
+              <tr>
+                <th><label class="checkbox"><input type="checkbox" data-index="Comedy" class="no"> Comedy <i class="fas fa-laugh-squint"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Crime" class="no"> Crime <i class="fas fa-user-ninja"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Thriller" class="no"> Thriller <i class="fas fa-crow"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Adventure" class="no"> Adventure <i class="fas fa-map-signs"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="Western" class="no"> Western <i class="fab fa-sticker-mule"></i></label></th>
+              </tr>       
+              <tr>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Family" class="no"> Family <i class="fas fa-home"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Fantasy" class="no"> Fantasy <i class="fas fa-dragon"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Action" class="no"> Action <i class="fas fa-bomb"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Documentary" class="no"> Doc <i class="fas fa-video"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Horror" class="no"> Horror <i class="fas fa-ghost"></i></label></th>
+                </tr>         
                 <tr>
-                  <th><label class="checkbox"><input type="checkbox"> Comedy <i class="fas fa-laugh-squint"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox"> Crime <i class="fas fa-user-ninja"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox"> Thriller <i class="fas fa-crow"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox"> Adventure <i class="fas fa-map-signs"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox"> Sport <i class="fas fa-football-ball"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Romance" class="no"> Romance <i class="fas fa-heart"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="TV Movie" class="no"> TV Movie <i class="fas fa-tv"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="History" class="no"> History <i class="fab fa-fort-awesome"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Mystery" class="no"> Mystery <i class="fas fa-user-secret"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Music" class="no"> Musical <i class="fas fa-music"></i></label></th>
+                </tr>         
+                <tr>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Drama" class="no"> Drama <i class="fas fa-theater-masks"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Science Fiction" class="no"> Sci-Fi <i class="fas fa-robot"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="War" class="no"> War <i class="fas fa-fighter-jet"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="Animation" class="no"> Animation <i class="fab fa-optin-monster"></i></label></th>
+
                 </tr>       
-                <tr>
-                    <th><label class="checkbox"><input type="checkbox"> Family <i class="fas fa-home"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> Fantasy <i class="fas fa-dragon"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> Action <i class="fas fa-bomb"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> Detective <i class="fas fa-user-secret"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> Horror <i class="fas fa-ghost"></i></label></th>
-                  </tr>         
-                  <tr>
-                    <th><label class="checkbox"><input type="checkbox"> Romance <i class="fas fa-heart"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> Biography <i class="fas fa-user-tie"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> History <i class="fab fa-fort-awesome"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> Mystery <i class="fas fa-search"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> Musical <i class="fas fa-music"></i></label></th>
-                  </tr>         
-                  <tr>
-                    <th><label class="checkbox"><input type="checkbox"> Drama <i class="fas fa-theater-masks"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> Sci-Fi <i class="fas fa-robot"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> War <i class="fas fa-fighter-jet"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> Animation <i class="fab fa-optin-monster"></i></label></th>
-                    <th><label class="checkbox"><input type="checkbox"> Western <i class="fab fa-sticker-mule"></i></label></th>
-                  </tr>         
               </table>
         </div>
       </div>
 
     </div>
 
-      <button class="button is-large">NEXT</button>
+      <input type="submit" name="submit" value="Next" class="button is-large">
+  </form>
 
 </main>
 <script src="https://code.jquery.com/jquery-3.6.0.js" integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk=" crossorigin="anonymous"></script>
 <script src="../navigation-bar/js/nav.js"></script>
 <script src="js/genres.js"></script>
+
 </body>
 </html>

--- a/src/containers/genres/genres.html
+++ b/src/containers/genres/genres.html
@@ -28,32 +28,31 @@
         <div class = "box">
           <table class = "table">
             <tr>
-              <th><label class="checkbox"><input type="checkbox" data-index="Comedy" class="yes"> Comedy <i class="fas fa-laugh-squint"></i></label></th>
-              <th><label class="checkbox"><input type="checkbox" data-index="Crime" class="yes"> Crime <i class="fas fa-user-ninja"></i></label></th>
-              <th><label class="checkbox"><input type="checkbox" data-index="Thriller" class="yes"> Thriller <i class="fas fa-crow"></i></label></th>
-              <th><label class="checkbox"><input type="checkbox" data-index="Adventure" class="yes"> Adventure <i class="fas fa-map-signs"></i></label></th>
-              <th><label class="checkbox"><input type="checkbox" data-index="Western" class="yes"> Western <i class="fab fa-sticker-mule"></i></label></th>
+              <th><label class="checkbox"><input type="checkbox" data-index="35" class="yes"> Comedy <i class="fas fa-laugh-squint"></i></label></th>
+              <th><label class="checkbox"><input type="checkbox" data-index="80" class="yes"> Crime <i class="fas fa-user-ninja"></i></label></th>
+              <th><label class="checkbox"><input type="checkbox" data-index="53" class="yes"> Thriller <i class="fas fa-crow"></i></label></th>
+              <th><label class="checkbox"><input type="checkbox" data-index="12" class="yes"> Adventure <i class="fas fa-map-signs"></i></label></th>
+              <th><label class="checkbox"><input type="checkbox" data-index="37" class="yes"> Western <i class="fab fa-sticker-mule"></i></label></th>
             </tr>       
             <tr>
-                <th><label class="checkbox"><input type="checkbox" data-index="Family" class="yes"> Family <i class="fas fa-home"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Fantasy" class="yes"> Fantasy <i class="fas fa-dragon"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Action" class="yes"> Action <i class="fas fa-bomb"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Documentary" class="yes"> Doc <i class="fas fa-video"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Horror" class="yes"> Horror <i class="fas fa-ghost"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="10751" class="yes"> Family <i class="fas fa-home"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="14" class="yes"> Fantasy <i class="fas fa-dragon"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="28" class="yes"> Action <i class="fas fa-bomb"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="99" class="yes"> Doc <i class="fas fa-video"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="27" class="yes"> Horror <i class="fas fa-ghost"></i></label></th>
               </tr>         
               <tr>
-                <th><label class="checkbox"><input type="checkbox" data-index="Romance" class="yes"> Romance <i class="fas fa-heart"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="TV Movie" class="yes"> TV Movie <i class="fas fa-tv"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="History" class="yes"> History <i class="fab fa-fort-awesome"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Mystery" class="yes"> Mystery <i class="fas fa-user-secret"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Music" class="yes"> Musical <i class="fas fa-music"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="10749" class="yes"> Romance <i class="fas fa-heart"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="10770" class="yes"> TV Movie <i class="fas fa-tv"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="36" class="yes"> History <i class="fab fa-fort-awesome"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="9648" class="yes"> Mystery <i class="fas fa-user-secret"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="10402" class="yes"> Musical <i class="fas fa-music"></i></label></th>
               </tr>         
               <tr>
-                <th><label class="checkbox"><input type="checkbox" data-index="Drama" class="yes"> Drama <i class="fas fa-theater-masks"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Science Fiction" class="yes"> Sci-Fi <i class="fas fa-robot"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="War" class="yes"> War <i class="fas fa-fighter-jet"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Animation" class="yes"> Animation <i class="fab fa-optin-monster"></i></label></th>
-
+                <th><label class="checkbox"><input type="checkbox" data-index="18" class="yes"> Drama <i class="fas fa-theater-masks"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="878" class="yes"> Sci-Fi <i class="fas fa-robot"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="10752" class="yes"> War <i class="fas fa-fighter-jet"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="16" class="yes"> Animation <i class="fab fa-optin-monster"></i></label></th>
               </tr>         
           </table>
         </div>
@@ -64,33 +63,32 @@
           <div class = "box">
             <table class = "table">
               <tr>
-                <th><label class="checkbox"><input type="checkbox" data-index="Comedy" class="no"> Comedy <i class="fas fa-laugh-squint"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Crime" class="no"> Crime <i class="fas fa-user-ninja"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Thriller" class="no"> Thriller <i class="fas fa-crow"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Adventure" class="no"> Adventure <i class="fas fa-map-signs"></i></label></th>
-                <th><label class="checkbox"><input type="checkbox" data-index="Western" class="no"> Western <i class="fab fa-sticker-mule"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="35" class="no"> Comedy <i class="fas fa-laugh-squint"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="80" class="no"> Crime <i class="fas fa-user-ninja"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="53" class="no"> Thriller <i class="fas fa-crow"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="12" class="no"> Adventure <i class="fas fa-map-signs"></i></label></th>
+                <th><label class="checkbox"><input type="checkbox" data-index="37" class="no"> Western <i class="fab fa-sticker-mule"></i></label></th>
               </tr>       
               <tr>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Family" class="no"> Family <i class="fas fa-home"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Fantasy" class="no"> Fantasy <i class="fas fa-dragon"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Action" class="no"> Action <i class="fas fa-bomb"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Documentary" class="no"> Doc <i class="fas fa-video"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Horror" class="no"> Horror <i class="fas fa-ghost"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="10751" class="no"> Family <i class="fas fa-home"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="14" class="no"> Fantasy <i class="fas fa-dragon"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="28" class="no"> Action <i class="fas fa-bomb"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="99" class="no"> Doc <i class="fas fa-video"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="27" class="no"> Horror <i class="fas fa-ghost"></i></label></th>
                 </tr>         
                 <tr>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Romance" class="no"> Romance <i class="fas fa-heart"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="TV Movie" class="no"> TV Movie <i class="fas fa-tv"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="History" class="no"> History <i class="fab fa-fort-awesome"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Mystery" class="no"> Mystery <i class="fas fa-user-secret"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Music" class="no"> Musical <i class="fas fa-music"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="10749" class="no"> Romance <i class="fas fa-heart"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="10770" class="no"> TV Movie <i class="fas fa-tv"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="36" class="no"> History <i class="fab fa-fort-awesome"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="9648" class="no"> Mystery <i class="fas fa-user-secret"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="10402" class="no"> Musical <i class="fas fa-music"></i></label></th>
                 </tr>         
                 <tr>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Drama" class="no"> Drama <i class="fas fa-theater-masks"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Science Fiction" class="no"> Sci-Fi <i class="fas fa-robot"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="War" class="no"> War <i class="fas fa-fighter-jet"></i></label></th>
-                  <th><label class="checkbox"><input type="checkbox" data-index="Animation" class="no"> Animation <i class="fab fa-optin-monster"></i></label></th>
-
-                </tr>       
+                  <th><label class="checkbox"><input type="checkbox" data-index="18" class="no"> Drama <i class="fas fa-theater-masks"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="878" class="no"> Sci-Fi <i class="fas fa-robot"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="10752" class="no"> War <i class="fas fa-fighter-jet"></i></label></th>
+                  <th><label class="checkbox"><input type="checkbox" data-index="16" class="no"> Animation <i class="fab fa-optin-monster"></i></label></th>
+                </tr>    
               </table>
         </div>
       </div>

--- a/src/containers/genres/genres.html
+++ b/src/containers/genres/genres.html
@@ -15,13 +15,7 @@
     <title>Watch and Chill</title>
 </head>
 <body>
-  <header>
-
-  </header>
-
-  <nav>
-
-  </nav>
+  <nav></nav>
 
   <main>
     
@@ -104,6 +98,7 @@
       <button class="button is-large">NEXT</button>
 
 </main>
-<script src="./src/containers/navigation-bar/js/nav.js"></script>
+<script src="https://code.jquery.com/jquery-3.6.0.js" integrity="sha256-H+K7U5CnXl1h5ywQfKtSj8PCmoN9aaq30gDh27Xc0jk=" crossorigin="anonymous"></script>
+<script src="../navigation-bar/js/nav.js"></script>
 </body>
 </html>

--- a/src/containers/genres/genres.html
+++ b/src/containers/genres/genres.html
@@ -101,7 +101,7 @@
 
     </div>
 
-      <button class="button is-large">BUTTON</button>
+      <button class="button is-large">NEXT</button>
 
 </main>
 <script src="./src/containers/navigation-bar/js/nav.js"></script>

--- a/src/containers/genres/js/genres.js
+++ b/src/containers/genres/js/genres.js
@@ -2,15 +2,8 @@ var nextBtn = document.querySelector("input.button");
 
 nextBtn.addEventListener("click", storeGenreOptions);
 
-input = document.querySelectorAll("input");
-
 inputYes = document.querySelectorAll("input.yes");
 inputNo = document.querySelectorAll("input.no");
-
-console.log(input);
-console.log(inputYes);
-console.log(inputNo);
-
 
 var label = document.querySelectorAll("label");
 
@@ -22,13 +15,6 @@ label[i].addEventListener("click", uncheck);
 
  function uncheck(event) {
     
-    console.log(event.target.className);
-    console.log(event.target.dataset.index);
-    console.log(inputNo[0].checked);
-    console.log(event.target.dataset.index === inputNo[0].dataset.index);
-
-
-
 
     for (var i = 0; i < inputYes.length; i++) {
 
@@ -44,13 +30,7 @@ label[i].addEventListener("click", uncheck);
 
     }
 
-    
-
-    
-
 }
-
-
 
 function storeGenreOptions(event) {
 

--- a/src/containers/genres/js/genres.js
+++ b/src/containers/genres/js/genres.js
@@ -1,0 +1,90 @@
+var nextBtn = document.querySelector("input.button");
+
+nextBtn.addEventListener("click", storeGenreOptions);
+
+input = document.querySelectorAll("input");
+
+inputYes = document.querySelectorAll("input.yes");
+inputNo = document.querySelectorAll("input.no");
+
+console.log(input);
+console.log(inputYes);
+console.log(inputNo);
+
+
+var label = document.querySelectorAll("label");
+
+for (var i = 0; i < label.length; i++) {
+
+label[i].addEventListener("click", uncheck);
+
+}
+
+ function uncheck(event) {
+    
+    console.log(event.target.className);
+    console.log(event.target.dataset.index);
+    console.log(inputNo[0].checked);
+    console.log(event.target.dataset.index === inputNo[0].dataset.index);
+
+
+
+
+    for (var i = 0; i < inputYes.length; i++) {
+
+    if (event.target.className === "yes" && event.target.dataset.index === inputNo[i].dataset.index && inputNo[i].checked === true) {
+
+        inputNo[i].checked = false;
+
+    } else if (event.target.className === "no" && event.target.dataset.index === inputYes[i].dataset.index && inputYes[i].checked === true) {
+
+        inputYes[i].checked = false;
+
+    }
+
+    }
+
+    
+
+    
+
+}
+
+
+
+function storeGenreOptions(event) {
+
+    event.preventDefault();
+
+    var yesGenreArray = [];
+    var noGenreArray = [];
+
+    for (var i = 0; i < inputYes.length; i++) {
+
+    if (inputYes[i].checked === true) {
+        yesGenreArray.push(inputYes[i].dataset.index);
+    };
+
+};
+
+    for (var i = 0; i < inputNo.length; i++)  {
+    
+    if (inputNo[i].checked === true) {
+        noGenreArray.push(inputNo[i].dataset.index);
+    };
+
+};
+    
+
+localStorage.setItem("yesGenres", JSON.stringify(yesGenreArray));
+localStorage.setItem("noGenres", JSON.stringify(noGenreArray));
+
+goToNextPage();
+
+};
+
+function goToNextPage() {
+
+    document.location.replace("../extra-options/extra-options.html");
+
+}

--- a/src/containers/genres/js/genres.js
+++ b/src/containers/genres/js/genres.js
@@ -1,70 +1,48 @@
 var nextBtn = document.querySelector("input.button");
+var inputYes = document.querySelectorAll("input.yes");
+var inputNo = document.querySelectorAll("input.no");
+var label = document.querySelectorAll("label");
 
 nextBtn.addEventListener("click", storeGenreOptions);
 
-inputYes = document.querySelectorAll("input.yes");
-inputNo = document.querySelectorAll("input.no");
-
-var label = document.querySelectorAll("label");
-
 for (var i = 0; i < label.length; i++) {
-
-label[i].addEventListener("click", uncheck);
-
+    label[i].addEventListener("click", uncheck);
 }
 
- function uncheck(event) {
-    
-
+function uncheck(event) {
     for (var i = 0; i < inputYes.length; i++) {
-
-    if (event.target.className === "yes" && event.target.dataset.index === inputNo[i].dataset.index && inputNo[i].checked === true) {
-
-        inputNo[i].checked = false;
-
-    } else if (event.target.className === "no" && event.target.dataset.index === inputYes[i].dataset.index && inputYes[i].checked === true) {
-
-        inputYes[i].checked = false;
-
+        if (event.target.className === "yes" && event.target.dataset.index === inputNo[i].dataset.index && inputNo[i].checked === true) {
+            inputNo[i].checked = false;
+        } else if (event.target.className === "no" && event.target.dataset.index === inputYes[i].dataset.index && inputYes[i].checked === true) {
+            inputYes[i].checked = false;
+        }
     }
-
-    }
-
 }
 
 function storeGenreOptions(event) {
-
     event.preventDefault();
 
     var yesGenreArray = [];
     var noGenreArray = [];
 
     for (var i = 0; i < inputYes.length; i++) {
-
-    if (inputYes[i].checked === true) {
-        yesGenreArray.push(inputYes[i].dataset.index);
+        if (inputYes[i].checked === true) {
+            yesGenreArray.push(inputYes[i].dataset.index);
+        };
     };
 
-};
-
-    for (var i = 0; i < inputNo.length; i++)  {
-    
-    if (inputNo[i].checked === true) {
-        noGenreArray.push(inputNo[i].dataset.index);
+    for (var i = 0; i < inputNo.length; i++) {
+        if (inputNo[i].checked === true) {
+            noGenreArray.push(inputNo[i].dataset.index);
+        };
     };
 
-};
-    
+    localStorage.setItem("yesGenres", JSON.stringify(yesGenreArray));
+    localStorage.setItem("noGenres", JSON.stringify(noGenreArray));
 
-localStorage.setItem("yesGenres", JSON.stringify(yesGenreArray));
-localStorage.setItem("noGenres", JSON.stringify(noGenreArray));
-
-goToNextPage();
-
+    goToNextPage();
 };
 
 function goToNextPage() {
-
     document.location.replace("../extra-options/extra-options.html");
-
 }


### PR DESCRIPTION
When clicking on the "Next" button:

Both the genres the user wants and the ones they don't get stored in two different arrays in the local storage.
The user travels to the next page, the extra options page.
If the user tries to select the same genre twice (in both "Hell Yeah! and "No way" boxes), only the last one they select will remain checked.

I also had to modify the html file and make changes in the genre options so that they match the ones available in the API.